### PR TITLE
Udp port choice

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.3
+
+### Connection and dockerized apps
+
+- Add new optional config `bind_ip` and `bind_port` for connections to be able to dockerise xknx's apps.
+- Add optional config `local_port` to be able to map a host udp port to a container udp port.
+- Read env vars after reading config file to allow dynamic config for dockerized apps.
+
 ## 0.15.2 Winter is coming
 
 ### Devices

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,14 @@ The configuration file can contain three sections.
     - `gateway_ip` (required) sets the ip address of the KNX tunneling interface
     - `gateway_port` (optional) sets the port the KNX tunneling interface is listening on
     - `local_ip` (optional) sets the ip address that is used by xknx
+    - `local_port` (optional) sets the udp port that is used by xknx
+    - `bind_ip` (optional) sets the ip address sent into command telegrams by xknx (for dockerised app)
+    - `bind_port` (optional) sets the udp port sent into command telegrams by xknx (for dockerised app)
   - `routing` for a UDP multicast connection
     - `local_ip` (optional) sets the ip address that is used by xknx
+    - `local_port` (optional) sets the udp port that is used by xknx
+    - `bind_ip` (optional) sets the ip address sent into command telegrams by xknx (for dockerised app)
+    - `bind_port` (optional) sets the udp port sent into command telegrams by xknx (for dockerised app)
 - Within the `groups` sections all devices are defined. For each type of device more then one section might be specified. You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
 
 ## How to use

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -171,6 +171,30 @@ loop.run_until_complete(main())
 loop.close()
 ```
 
+# [](#header-2)Dockerised xknx's app 
 
+If you planned to run xknx into a container, you have to setup udp port binding from your host to the container.
+The host ip and port must be setup into the configuration file or env variables.
 
+Available env variables are:
+- XKNX_GENERAL_OWN_ADDRESS
+- XKNX_GENERAL_RATE_LIMIT
+- XKNX_GENERAL_MULTICAST_GROUP
+- XKNX_GENERAL_MULTICAST_PORT
+- XKNX_CONNECTION_GATEWAY_IP: Your KNX Gateway IP address
+- XKNX_CONNECTION_GATEWAY_PORT: Your KNX Gateway UDP port
+- XKNX_CONNECTION_LOCAL_IP
+- XKNX_CONNECTION_LOCAL_PORT: Container internal UDP port, target of the forward from the host
+- XKNX_CONNECTION_BIND_IP: IP address of the host machine
+- XKNX_CONNECTION_BIND_PORT: UDP port used in the host machine, must be forwarded to the container
 
+Exanple of a `docker run` with an xknx based app:
+
+```bash
+docker run --name myapp -d \
+  -e XKNX_CONNECTION_GATEWAY_IP='192.168.0.123' \
+  -e XKNX_CONNECTION_LOCAL_PORT=12399 \
+  -e XKNX_CONNECTION_BIND_IP='192.168.0.100' 
+  -e XKNX_CONNECTION_BIND_PORT=12300 \
+  -p 12300:12399/udp myapp:latest
+```

--- a/xknx/__version__.py
+++ b/xknx/__version__.py
@@ -1,3 +1,3 @@
 """XKNX version."""
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"

--- a/xknx/config/config_v1.py
+++ b/xknx/config/config_v1.py
@@ -6,6 +6,7 @@ Module for reading config files (xknx.yaml).
 """
 from enum import Enum
 import logging
+import os
 
 from xknx.devices import (
     BinarySensor,
@@ -42,10 +43,12 @@ class ConfigV1:
         self.xknx = xknx
 
     def parse(self, doc):
-        """Parse the config."""
+        """Parse the config and read ENV vars."""
         self.parse_general(doc)
         self.parse_connection(doc)
         self.parse_groups(doc)
+        self.env_general()
+        self.env_connection()
 
     def parse_general(self, doc):
         """Parse the general section of xknx.yaml."""
@@ -58,6 +61,17 @@ class ConfigV1:
                 self.xknx.multicast_group = doc["general"]["multicast_group"]
             if "multicast_port" in doc["general"]:
                 self.xknx.multicast_port = doc["general"]["multicast_port"]
+
+    def env_general(self):
+        """Get Env Vars for the general section."""
+        if os.getenv('XKNX_GENERAL_OWN_ADDRESS', default=None):
+            self.xknx.own_address = os.getenv('XKNX_GENERAL_OWN_ADDRESS')
+        if os.getenv('XKNX_GENERAL_RATE_LIMIT', default=None):
+            self.xknx.rate_limit = os.getenv('XKNX_GENERAL_RATE_LIMIT')
+        if os.getenv('XKNX_GENERAL_MULTICAST_GROUP', default=None):
+            self.xknx.multicast_group = os.getenv('XKNX_GENERAL_MULTICAST_GROUP')
+        if os.getenv('XKNX_GENERAL_MULTICAST_PORT', default=None):
+            self.xknx.multicast_port = os.getenv('XKNX_GENERAL_MULTICAST_PORT')
 
     def parse_connection(self, doc):
         """Parse the connection section of xknx.yaml."""
@@ -100,6 +114,20 @@ class ConfigV1:
                 elif pref == "bind_port":
                     connection_config.bind_port = value
         self.xknx.connection_config = connection_config
+
+    def env_connection(self):
+        if os.getenv('XKNX_CONNECTION_GATEWAY_IP', default=None):
+            self.xknx.connection_config.gateway_ip = os.getenv('XKNX_CONNECTION_GATEWAY_IP')
+        if os.getenv('XKNX_CONNECTION_GATEWAY_PORT', default=None):
+            self.xknx.connection_config.gateway_port = os.getenv('XKNX_CONNECTION_GATEWAY_PORT')
+        if os.getenv('XKNX_CONNECTION_LOCAL_IP', default=None):
+            self.xknx.connection_config.local_ip = os.getenv('XKNX_CONNECTION_LOCAL_IP')
+        if os.getenv('XKNX_CONNECTION_LOCAL_PORT', default=None):
+            self.xknx.connection_config.local_port = os.getenv('XKNX_CONNECTION_LOCAL_PORT')
+        if os.getenv('XKNX_CONNECTION_BIND_IP', default=None):
+            self.xknx.connection_config.bind_ip = os.getenv('XKNX_CONNECTION_BIND_IP')
+        if os.getenv('XKNX_CONNECTION_BIND_PORT', default=None):
+            self.xknx.connection_config.bind_port = os.getenv('XKNX_CONNECTION_BIND_PORT')
 
     def parse_groups(self, doc):
         """Parse the group section of xknx.yaml."""

--- a/xknx/config/config_v1.py
+++ b/xknx/config/config_v1.py
@@ -93,6 +93,12 @@ class ConfigV1:
                     connection_config.gateway_port = value
                 elif pref == "local_ip":
                     connection_config.local_ip = value
+                elif pref == "local_port":
+                    connection_config.local_port = value
+                elif pref == "bind_ip":
+                    connection_config.bind_ip = value
+                elif pref == "bind_port":
+                    connection_config.bind_port = value
         self.xknx.connection_config = connection_config
 
     def parse_groups(self, doc):

--- a/xknx/io/connect.py
+++ b/xknx/io/connect.py
@@ -13,10 +13,10 @@ from .request_response import RequestResponse
 class Connect(RequestResponse):
     """Class to send a ConnectRequest and wait for ConnectResponse.."""
 
-    def __init__(self, xknx, udp_client):
+    def __init__(self, xknx, udp_client, net_bind=None):
         """Initialize Connect class."""
         self.udp_client = udp_client
-        super().__init__(xknx, self.udp_client, ConnectResponse)
+        super().__init__(xknx, self.udp_client, ConnectResponse, net_bind=net_bind)
         self.communication_channel = 0
         self.identifier = 0
 
@@ -24,7 +24,10 @@ class Connect(RequestResponse):
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udp_client.getsockname()
         # set control_endpoint and data_endpoint to the same udp_connection
-        endpoint = HPAI(ip_addr=local_addr, port=local_port)
+        if self.net_bind:
+            endpoint = HPAI(ip_addr=self.net_bind[0], port=self.net_bind[1])
+        else:
+            endpoint = HPAI(ip_addr=local_addr, port=local_port)
         connect_request = ConnectRequest(
             self.xknx,
             request_type=ConnectRequestType.TUNNEL_CONNECTION,

--- a/xknx/io/connectionstate.py
+++ b/xknx/io/connectionstate.py
@@ -7,18 +7,22 @@ from .request_response import RequestResponse
 class ConnectionState(RequestResponse):
     """Class to send ConnectonStateRequest and wait for ConnectionStateResponse."""
 
-    def __init__(self, xknx, udp_client, communication_channel_id):
+    def __init__(self, xknx, udp_client, communication_channel_id, net_bind):
         """Initialize ConnectionState class."""
         self.udp_client = udp_client
-        super().__init__(xknx, self.udp_client, ConnectionStateResponse)
+        super().__init__(xknx, self.udp_client, ConnectionStateResponse, net_bind=net_bind)
         self.communication_channel_id = communication_channel_id
 
     def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udpclient.getsockname()
+        if self.net_bind:
+            endpoint = HPAI(ip_addr=self.net_bind[0], port=self.net_bind[1])
+        else:
+            endpoint = HPAI(ip_addr=local_addr, port=local_port)
         connectionstate_request = ConnectionStateRequest(
             self.xknx,
             communication_channel_id=self.communication_channel_id,
-            control_endpoint=HPAI(ip_addr=local_addr, port=local_port),
+            control_endpoint=endpoint,
         )
         return KNXIPFrame.init_from_body(connectionstate_request)

--- a/xknx/io/disconnect.py
+++ b/xknx/io/disconnect.py
@@ -7,19 +7,23 @@ from .request_response import RequestResponse
 class Disconnect(RequestResponse):
     """Class to send a DisconnectRequest and wait for a DisconnectResponse."""
 
-    def __init__(self, xknx, udp_client, communication_channel_id):
+    def __init__(self, xknx, udp_client, communication_channel_id, net_bind=None):
         """Initialize Disconnect class."""
         self.xknx = xknx
         self.udp_client = udp_client
-        super().__init__(xknx, self.udp_client, DisconnectResponse)
+        super().__init__(xknx, self.udp_client, DisconnectResponse, net_bind=net_bind)
         self.communication_channel_id = communication_channel_id
 
     def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udpclient.getsockname()
+        if self.net_bind:
+            endpoint = HPAI(ip_addr=self.net_bind[0], port=self.net_bind[1])
+        else:
+            endpoint = HPAI(ip_addr=local_addr, port=local_port)
         disconnect_request = DisconnectRequest(
             self.xknx,
             communication_channel_id=self.communication_channel_id,
-            control_endpoint=HPAI(ip_addr=local_addr, port=local_port),
+            control_endpoint=endpoint,
         )
         return KNXIPFrame.init_from_body(disconnect_request)

--- a/xknx/io/request_response.py
+++ b/xknx/io/request_response.py
@@ -16,10 +16,11 @@ class RequestResponse:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, xknx, udp_client, awaited_response_class, timeout_in_seconds=1):
+    def __init__(self, xknx, udp_client, awaited_response_class, timeout_in_seconds=1, net_bind=None):
         """Initialize RequstResponse class."""
         self.xknx = xknx
         self.udpclient = udp_client
+        self.net_bind = net_bind
         self.awaited_response_class = awaited_response_class
         self.response_received_or_timeout = asyncio.Event()
         self.success = False

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("xknx.log")
 class Routing:
     """Class for handling KNX/IP routing."""
 
-    def __init__(self, xknx, telegram_received_callback, local_ip):
+    def __init__(self, xknx, telegram_received_callback, local_ip, local_port):
         """Initialize Routing class."""
         self.xknx = xknx
         self.telegram_received_callback = telegram_received_callback
@@ -31,7 +31,7 @@ class Routing:
 
         self.udpclient = UDPClient(
             self.xknx,
-            (local_ip, 0),
+            (local_ip, local_port),
             (self.xknx.multicast_group, self.xknx.multicast_port),
             multicast=True,
         )

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -34,8 +34,11 @@ class Tunnel:
         self,
         xknx,
         local_ip,
+        local_port,
         gateway_ip,
         gateway_port,
+        bind_ip=None,
+        bind_port=0,
         telegram_received_callback=None,
         auto_reconnect=False,
         auto_reconnect_wait=3,
@@ -44,6 +47,9 @@ class Tunnel:
         # pylint: disable=too-many-arguments
         self.xknx = xknx
         self.local_ip = local_ip
+        self.local_port = local_port
+        self.bind_ip = bind_ip
+        self.bind_port = bind_port
         self.gateway_ip = gateway_ip
         self.gateway_port = gateway_port
         self.telegram_received_callback = telegram_received_callback
@@ -67,7 +73,7 @@ class Tunnel:
     def init_udp_client(self):
         """Initialize udp_client."""
         self.udp_client = UDPClient(
-            self.xknx, (self.local_ip, 0), (self.gateway_ip, self.gateway_port)
+            self.xknx, (self.local_ip, self.local_port), (self.gateway_ip, self.gateway_port)
         )
 
         self.udp_client.register_callback(
@@ -115,7 +121,7 @@ class Tunnel:
 
     async def connect(self):
         """Connect/build tunnel."""
-        connect = Connect(self.xknx, self.udp_client)
+        connect = Connect(self.xknx, self.udp_client, net_bind=(self.bind_ip, self.bind_port))
         await connect.start()
         if not connect.success:
             if self.auto_reconnect:
@@ -197,6 +203,7 @@ class Tunnel:
             self.xknx,
             self.udp_client,
             communication_channel_id=self.communication_channel,
+            net_bind=(self.bind_ip, self.bind_port)
         )
         await conn_state.start()
         return conn_state.success
@@ -212,6 +219,7 @@ class Tunnel:
             self.xknx,
             self.udp_client,
             communication_channel_id=self.communication_channel,
+            net_bind=(self.bind_ip, self.bind_port)
         )
         await disconnect.start()
         if not disconnect.success and not ignore_error:

--- a/xknx_v2.yaml
+++ b/xknx_v2.yaml
@@ -8,7 +8,10 @@ multicast_group: '224.1.2.3'
 multicast_port: 1337
 connection: # optional
   type: tunneling # or routing|auto
-  local_ip: "192.168.0.201"
+  local_ip: "192.168.111.201"
+  local_port: 42424
+  bind_ip: "192.168.0.201"
+  bind_port: 42424
   host: "192.168.0.202"
   port: 1337
 binary_sensor:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Trying to run xknx into a docker container, their is 2 troubles:
- automatic local udp port (throw 0) do not allowed us to forward the host udp port to a named udp port of the container
- using the local ip and port in the Connect, Disconnect and ConnectionState is not working, it is the host ip and port that must be sent to the KNX Gateway.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
